### PR TITLE
fix(csv import) replace lookbehind in parse decimal regex

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,11 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['vue', 'jest'],
-  rules: {},
+  plugins: ['vue', 'jest', 'es'],
+  rules: {
+    'es/no-regexp-lookbehind-assertions': 'error',
+    'es/no-regexp-named-capture-groups': 'error',
+    'es/no-regexp-s-flag': 'error',
+    'es/no-regexp-unicode-property-escapes': 'error',
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4295,6 +4295,33 @@
         }
       }
     },
+    "eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
+        "regexpp": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+          "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-jest": {
       "version": "23.8.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "copy-webpack-plugin": "^6.0.4",
     "date-fns": "^2.16.1",
     "eslint": "^6.8.0",
+    "eslint-plugin-es": "^4.1.0",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-vue": "^6.2.2",
     "file-loader": "^6.0.0",

--- a/src/apps/generic/csv/utils.js
+++ b/src/apps/generic/csv/utils.js
@@ -112,7 +112,7 @@ const parseDecimal = (value, defaultValue) => {
   const normalized = trimmedValue.replace(',', '.');
 
   // Accepts only numbers and a maximum of one floating point
-  if (!/^(\d*|\d+\.\d+)$/.test(normalized)) {
+  if (!/^(\d+|\d+\.\d+)$/.test(normalized)) {
     throw new ParqetParserError(
       'Decimal value must only contain numbers and maximum of one floating point',
       trimmedValue

--- a/src/apps/generic/csv/utils.js
+++ b/src/apps/generic/csv/utils.js
@@ -112,7 +112,7 @@ const parseDecimal = (value, defaultValue) => {
   const normalized = trimmedValue.replace(',', '.');
 
   // Accepts only numbers and a maximum of one floating point
-  if (!/(?<=^| )\d+(\.\d+)?(?=$| )/.test(normalized)) {
+  if (!/^(\d*|\d+\.\d+)$/.test(normalized)) {
     throw new ParqetParserError(
       'Decimal value must only contain numbers and maximum of one floating point',
       trimmedValue


### PR DESCRIPTION
@dredav
Replaced regex lookbehind with simplified regex.

To prevent this from happening in the future, I researched a bit on how to test it.
According to this [stack overflow post](https://stackoverflow.com/a/64460424) the simplest way would be to install an eslint plugin to notify the devs right away + prevent transpilation.

This is the plugin: [eslint-plugin-es](https://github.com/mysticatea/eslint-plugin-es)
Here is how it looks when enabled:

<img width="818" alt="Screen Shot 2021-11-03 at 22 06 59" src="https://user-images.githubusercontent.com/36050523/140033870-5b2b3eb2-56cc-4453-8922-7a84329f47bf.png">

It also prevents some other regex issues in safari. Here are the rules i have added:

```js
//.eslint.rc

 ...
 rules: {
    'es/no-regexp-lookbehind-assertions': 'error',
    'es/no-regexp-named-capture-groups': 'error',
    'es/no-regexp-s-flag': 'error',
    'es/no-regexp-unicode-property-escapes': 'error',
 }
 ...
```

I have added it in a commit. Can roll back if you want. 